### PR TITLE
pairs update script and config for north america

### DIFF
--- a/scripts/provider-pairs.py
+++ b/scripts/provider-pairs.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import sys
+import requests
+import yaml
+
+def get_pairs(provider):
+    if provider == "binance":
+        info_res = requests.get("https://api.binance.us/api/v3/exchangeInfo")
+        info_res.raise_for_status()
+        symbols = [f"{s['baseAsset']}/{s['quoteAsset']}" for s in info_res.json()["symbols"]]
+        return symbols
+    elif provider == "binanceus":
+        info_res = requests.get("https://api.binance.us/api/v3/exchangeInfo")
+        info_res.raise_for_status()
+        symbols = [f"{s['baseAsset']}-{s['quoteAsset']}" for s in info_res.json()["symbols"]]
+        return symbols
+    else:
+        raise RuntimeError("provider not supported")
+
+def extend_yaml_config(provider, symbols, config_data):
+    config_symbols = config_data["currency_pairs"]
+    for symbol, data in config_symbols.items():
+        providers = data["providers"]
+        if symbol in symbols:
+            providers_list = providers.split(",")
+            if provider not in providers_list:
+                providers_list.append(provider)
+                config_data["currency_pairs"][symbol]["providers"] = ", ".join(providers_list)
+
+def remove_yaml_config(provider, config_data):
+    config_symbols = config_data["currency_pairs"]
+    for symbol, data in config_symbols.items():
+        providers = data["providers"]
+        providers_list = [p.strip() for p in providers.split(",")]
+        if provider in providers_list:
+            providers_list.remove(provider)
+            config_data["currency_pairs"][symbol]["providers"] = ", ".join(providers_list)
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("usage: get-pairs.py <provider> [yaml_config]")
+        print("\toutputs pairs supported by provider.")
+        print("\tif yaml config is provided, outputs a modified config with the provider added to supported pairs.")
+        print("\tprefix the provider name with a dash to remove it from all pairs in the config where it exists.")
+        sys.exit(-1)
+    provider = sys.argv[1]
+    is_negated = provider.startswith("-")
+    if is_negated:
+        provider = provider[1:]
+    if len(sys.argv) == 2:
+        if is_negated:
+            raise RuntimeError("negation not supported with one argument")
+        print(get_pairs(provider))
+    elif len(sys.argv) > 2:
+        with open(sys.argv[2], "rb") as f:
+            config_data = yaml.safe_load(f)
+        if is_negated:
+            remove_yaml_config(provider, config_data)
+        else:
+            symbols = get_pairs(provider)
+            extend_yaml_config(provider, symbols, config_data)
+        print(yaml.safe_dump(config_data, width=float("inf")))

--- a/scripts/provider-pairs.py
+++ b/scripts/provider-pairs.py
@@ -3,17 +3,16 @@ import sys
 import requests
 import yaml
 
+def get_pairs_binance(endpoint):
+    info_res = requests.get(f"{endpoint}/api/v3/exchangeInfo")
+    info_res.raise_for_status()
+    return [f"{s['baseAsset']}-{s['quoteAsset']}" for s in info_res.json()["symbols"]]
+
 def get_pairs(provider):
     if provider == "binance":
-        info_res = requests.get("https://api.binance.us/api/v3/exchangeInfo")
-        info_res.raise_for_status()
-        symbols = [f"{s['baseAsset']}/{s['quoteAsset']}" for s in info_res.json()["symbols"]]
-        return symbols
+        return get_pairs_binance("https://api.binance.com")
     elif provider == "binanceus":
-        info_res = requests.get("https://api.binance.us/api/v3/exchangeInfo")
-        info_res.raise_for_status()
-        symbols = [f"{s['baseAsset']}-{s['quoteAsset']}" for s in info_res.json()["symbols"]]
-        return symbols
+        return get_pairs_binance("https://api.binance.us")
     else:
         raise RuntimeError("provider not supported")
 

--- a/scripts/provider-pairs.py
+++ b/scripts/provider-pairs.py
@@ -21,7 +21,7 @@ def extend_yaml_config(provider, symbols, config_data):
     for symbol, data in config_symbols.items():
         providers = data["providers"]
         if symbol in symbols:
-            providers_list = providers.split(",")
+            providers_list = [p.strip() for p in providers.split(",")]
             if provider not in providers_list:
                 providers_list.append(provider)
                 config_data["currency_pairs"][symbol]["providers"] = ", ".join(providers_list)

--- a/yaml/global.yml
+++ b/yaml/global.yml
@@ -247,6 +247,8 @@ url_sets:
     - https://example
   rpc_ethereum:
     - https://example
+  fin:
+    - https://example
 
 endpoints:
   astroport_neutron:

--- a/yaml/north_america.yml
+++ b/yaml/north_america.yml
@@ -268,4 +268,5 @@ url_sets:
   - https://example
   rpc_ethereum:
   - https://example
-
+  fin:
+  - https://example

--- a/yaml/north_america.yml
+++ b/yaml/north_america.yml
@@ -1,0 +1,271 @@
+contracts:
+  astroport_neutron:
+    NTRNATOM: neutron1e22zh5p8meddxjclevuhjmfj69jxfsa8uu3jvht72rv9d8lkhves6t8veq
+  camelotv3:
+    KUJIWETH: '0x22427d20480de289795ca29c3adddb57a568e285'
+    WETHGMX: '0xC99be44383BC8d82357F5A1D9ae9976EE9d75bee'
+    WETHUSDC: '0x521aa84ab3fcc4c05cABaC24Dc3682339887B126'
+  finv2:
+    AMPKUJIKUJI: kujira1lse59wt7a5yksdd08mennt299katjkfzdhmh8hvck8ln08jktcmsxrnh8s
+    KUJIUSDC: kujira14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sl4e867
+    MNTAUSDC: kujira1ws9w7wl68prspv3rut3plv8249rm0ea0kk335swye3sl2slld4lqdmc0lv
+    NSTKUSK: kujira1ggtmfuktfcf6plhtdejyyqn5de5uge3tef0jv64ru68h2ctuvyqs3355mn
+    QCKUJIKUJI: kujira14wsrem89304kpkl6d0j58dl6479eekwt047ccs0qzv9f60w80wzs8rjq4j
+    QCMNTAMNTA: kujira1ujsr2ge7dr723kse7thjv2rm3k7dkmjaxqzdh8qkcnx5gqz57jsqxy4ker
+    SOMMMNTA: kujira1nx5lqc2j4w0ak5dxevj82lar5kunxwj5yamr39xqfazmkksx4f2sksf0hz
+    STARSMNTA: kujira1hsdzhyvuc2z3f8d3yae84uk62d69vk68vxgudkun7gccz6hvrvfq0vx6fd
+    STATOMMNTA: kujira1l2x5c2fjjnw9uhrfhtme9snw3tzs4jt8cm0q2ysqssx6zskxatesjm7w7f
+    USDCUSK: kujira1rwx6w02alc4kaz7xpyg3rlxpjl4g63x5jq292mkxgg65zqpn5llq202vh5
+    WHALEMNTA: kujira1865zmuchjd0g0xr2q5n6hm747s8xju5k8h6mympk4vmqefkuy3hqc66tcw
+    WINKUSK: kujira1qxtd87qus6uzvqs4jv9r0j9ccd4yla42s6qag7y8fp7hhv68nzas6hqxgw
+  osmosisv2:
+    JUNOOSMO: '1097'
+    MNTAOSMO: '1215'
+    SOMMOSMO: '627'
+    STARSOSMO: '604'
+    STATOMATOM: '1136'
+    STOSMOOSMO: '833'
+    WHALEOSMO: '1318'
+  pancakev3_bsc:
+    ETHRIO: '0x043681828303cdf9398f0768bf1da99feebf7ee8'
+  uniswapv3:
+    RLBWETH: '0x510100d5143e011db24e2aa38abe85d73d5b2177'
+    USDCWETH: '0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640'
+    WETHRIO: '0x5b7e3e37a1aa6369386e5939053779abd3597508'
+    WSTETHWETH: '0x109830a1AAaD605BbF02a9dFA7B0B92EC2FB7dAa'
+currency_pairs:
+  AKT-USD:
+    providers: crypto, kraken
+  AKT-USDT:
+    providers: gate, huobi, kucoin
+  AMPKUJI-KUJI:
+    providers: finv2
+    twap: 30m
+  ARB-USD:
+    providers: bitfinex,  coinbase,  crypto,  kraken, binanceus
+  ARB-USDT:
+    providers: bitget,  bybit,  gate,  hitbtc,  huobi,  kucoin,  lbank,  mexc,  okx,  phemex,  xt, binanceus
+  ATOM-USD:
+    providers: coinbase,  kraken, binanceus
+  ATOM-USDT:
+    providers: bitget,  bybit,  crypto,  gate,  hitbtc,  huobi,  kucoin,  lbank,  mexc,  okx,  phemex,  poloniex,  xt, binanceus
+  AVAX-USD:
+    providers: bitfinex,  coinbase,  kraken, binanceus
+  AVAX-USDT:
+    providers: bitget,  bybit,  crypto,  gate,  hitbtc,  huobi,  kucoin,  lbank,  mexc,  okx,  phemex,  poloniex,  xt, binanceus
+  AXL-MNTA:
+    providers: fin
+    twap: 30m
+  AXL-USD:
+    providers: coinbase,  crypto,  kraken, binanceus
+  AXL-USDT:
+    providers: huobi,  bybit,  mexc,  bitget,  kucoin,  gate, binanceus
+  BAND-USDT:
+    providers: bitget,  crypto,  gate,  hitbtc,  huobi,  kucoin,  okx,  phemex, binanceus
+  BNB-USDT:
+    providers: bitget,  bybit,  gate,  hitbtc,  huobi,  kucoin,  lbank,  mexc,  okx,  phemex,  poloniex,  xt, binanceus
+  BTC-USD:
+    providers: bitfinex,  coinbase, binanceus
+  BTC-USDT:
+    providers: bitget,  bybit,  crypto,  gate,  hitbtc,  huobi,  kucoin,  lbank,  mexc,  okx,  phemex,  poloniex,  xt, binanceus
+  CRO-USDT:
+    providers: bitget, crypto, gate, kucoin, lbank, mexc, okx, xt
+  DOT-USD:
+    providers: bitfinex,  coinbase,  crypto,  kraken, binanceus
+  DOT-USDT:
+    providers: bitget,  bybit,  gate,  hitbtc,  huobi,  kucoin,  lbank,  mexc,  okx,  phemex,  poloniex,  xt, binanceus
+  ETH-USD:
+    providers: bitfinex,  coinbase,  crypto, binanceus
+  ETH-USDT:
+    providers: bitget,  bybit,  gate,  hitbtc,  huobi,  kraken,  kucoin,  lbank,  mexc,  okx,  phemex,  poloniex,  xt, binanceus
+  FET-USD:
+    providers: bitfinex,  coinbase,  kraken, binanceus
+  FET-USDT:
+    providers: bitget,  crypto,  gate,  huobi,  kucoin,  lbank,  mexc,  phemex, binanceus
+  FTM-USD:
+    providers: bitfinex,  kraken, binanceus
+  FTM-USDT:
+    providers: bitget,  bybit,  crypto,  gate,  hitbtc,  huobi,  kucoin,  lbank,  mexc,  okx,  phemex, binanceus
+  GLMR-USDT:
+    providers: bitget, bybit, crypto, gate, huobi, kucoin, lbank, mexc, okx, xt
+  HNT-USD:
+    providers: coinbase,  crypto, binanceus
+  HNT-USDT:
+    providers: bitget,  gate,  kucoin,  bitmart,  bybit, binanceus
+  INJ-USD:
+    providers: coinbase, kraken
+  INJ-USDT:
+    providers: bitget, bybit, crypto, gate, hitbtc, huobi, kucoin, lbank, mexc, phemex
+  JUNO-OSMO:
+    providers: osmosisv2
+  JUNO-USD:
+    providers: kraken
+  JUNO-USDT:
+    providers: mexc
+  KAVA-USD:
+    providers: coinbase,  kraken, binanceus
+  KAVA-USDT:
+    providers: bitget,  crypto,  gate,  huobi,  kucoin,  lbank,  mexc,  xt, binanceus
+  KUJI-USDC:
+    providers: fin
+    twap: 30m
+  KUJI-USDT:
+    providers: mexc
+    twap: 30m
+  KUJI-WETH:
+    providers: camelotv3
+    twap: 30m
+  LINK-USD:
+    providers: coinbase,  kraken,  crypto, binanceus
+  LINK-USDT:
+    providers: okx,  lbank,  bybit,  gate,  phemex,  xt,  bitget,  huobi,  mexc, binanceus
+  LUNA-USD:
+    providers: kraken
+  LUNA-USDT:
+    providers: bitget, bybit, gate, hitbtc, huobi, kucoin, lbank, mexc, okx, phemex, xt
+  LUNC-USD:
+    providers: crypto, kraken
+  LUNC-USDT:
+    providers: bitget, bybit, gate, hitbtc, huobi, kucoin, lbank, mexc, okx, phemex, xt
+  MATIC-USD:
+    providers: bitfinex,  coinbase,  crypto,  kraken, binanceus
+  MATIC-USDT:
+    providers: bitget,  bybit,  gate,  hitbtc,  huobi,  kucoin,  lbank,  mexc,  okx,  phemex,  poloniex,  xt, binanceus
+  MNTA-USDC:
+    providers: finv2
+    twap: 30m
+  NSTK-USK:
+    providers: finv2
+    twap: 30m
+  NTRN-ATOM:
+    providers: astroport_neutron
+    twap: 30m
+  OSMO-USD:
+    providers: crypto
+  OSMO-USDT:
+    providers: bitget, gate, huobi, kucoin, lbank, mexc
+  PAXG-USD:
+    providers: kraken, binanceus
+  PAXG-USDT:
+    providers: bitget,  bybit,  crypto,  kucoin,  lbank,  mexc,  phemex, binanceus
+  QCKUJI-KUJI:
+    providers: finv2
+    twap: 30m
+  QCMNTA-MNTA:
+    providers: finv2
+    twap: 30m
+  RIO-ETH:
+    providers: pancakev3_bsc
+    twap: 30m
+  RIO-USDT:
+    providers: mexc, okx
+  RIO-WETH:
+    providers: uniswapv3
+    twap: 30m
+  RLB-WETH:
+    providers: uniswapv3
+    twap: 30m
+  SCRT-USD:
+    providers: kraken
+  SCRT-USDT:
+    providers: bybit, gate, huobi, kucoin, lbank, mexc
+  SOL-USD:
+    providers: coinbase,  kraken, binanceus
+  SOL-USDT:
+    providers: huobi,  okx,  bybit,  xt,  gate,  bitget,  kucoin, binanceus
+  SOMM-MNTA:
+    providers: finv2
+    twap: 30m
+  SOMM-OSMO:
+    providers: osmosisv2
+    twap: 30m
+  STARS-MNTA:
+    providers: finv2
+    twap: 30m
+  STARS-OSMO:
+    providers: osmosisv2
+    twap: 30m
+  STATOM-ATOM:
+    providers: osmosisv2
+    twap: 30m
+  STOSMO-OSMO:
+    providers: osmosisv2
+    twap: 30m
+  UNI-USD:
+    providers: coinbase,  kraken,  crypto, binanceus
+  UNI-USDT:
+    providers: okx,  lbank,  bybit,  gate,  phemex,  bitget,  huobi, binanceus
+  USDC-USD:
+    providers: kraken, binanceus
+  USDC-USDT:
+    providers: bitget,  bybit,  gate,  huobi,  kucoin,  lbank,  mexc,  okx,  phemex,  xt, binanceus
+  USDT-USD:
+    providers: binanceus, coinbase, crypto, gate, kraken
+  USK-USDC:
+    providers: finv2
+    twap: 30m
+  WBTC-BTC:
+    providers: coinbase,  kucoin,  okx, binanceus
+  WBTC-USDT:
+    providers: bitget, bybit, crypto, gate, hitbtc, mexc, phemex, poloniex
+  WETH-USDC:
+    providers: uniswapv3
+  WHALE-MNTA:
+    providers: fin
+    twap: 30m
+  WHALE-OSMO:
+    providers: osmosisv2
+    twap: 30m
+  WHALE-USDT:
+    providers: mexc
+    twap: 30m
+  WINK-USK:
+    providers: finv2
+    twap: 30m
+  WSTETH-WETH:
+    providers: uniswapv3
+    twap: 30m
+deviation_thresholds:
+  KUJI: 2
+  USDT: 2
+  WHALE: 2
+endpoints:
+  astroport_neutron:
+    url_set: api_neutron
+  fin:
+    url_set: fin
+  finv2:
+    url_set: api_kujira
+  osmosisv2:
+    url_set: api_osmosis
+  uniswapv3:
+    url_set: rpc_ethereum
+min_providers:
+  AMPKUJI: 1
+  JUNO: 1
+  KUJI: 2
+  MNTA: 1
+  NSTK: 1
+  NTRN: 1
+  QCKUJI: 1
+  QCMNTA: 1
+  RLB: 1
+  SOMM: 1
+  STARS: 1
+  STATOM: 1
+  STOSMO: 1
+  USK: 1
+  WETH: 1
+  WHALE: 1
+  WINK: 1
+  WSTETH: 1
+url_sets:
+  api_kujira:
+  - https://example
+  api_neutron:
+  - https://example
+  api_osmosis:
+  - https://example
+  rpc_ethereum:
+  - https://example
+


### PR DESCRIPTION
`provider-pairs.py` can get pairs supported by a provider and update the config file accordingly. initially supports `binance` and `binanceus`.

`north_america.yml` is a modified config for NA with `binance` removed and `binanceus` added.

example urlset config for `fin` added to both yaml configs.