### PR TITLE
Remove binance from DYDX, poloniex from WBTC

### DIFF
--- a/toml/north-america.toml
+++ b/toml/north-america.toml
@@ -202,7 +202,7 @@ providers = ["bitget", "bybit", "gate", "kucoin"]
 [[currency_pairs]]
 base = "DYDX"
 quote = "USDT"
-providers = ["binance", "gate", "huobi", "kucoin", "okx"]
+providers = ["gate", "huobi", "kucoin", "okx"]
 
 [[currency_pairs]]
 base = "DYDX"
@@ -733,7 +733,6 @@ providers = [
     "gate",
     "hitbtc",
     "phemex",
-    "poloniex",
 ]
 
 [[currency_pairs]]


### PR DESCRIPTION
`binance` isn't supported in NA (can't be used for DYDX), poloniex doesn't report WBTC/USDT as a valid pair